### PR TITLE
fixes off-by-one bug on max number allowed

### DIFF
--- a/contracts/c680z7fefr/README.md
+++ b/contracts/c680z7fefr/README.md
@@ -1,6 +1,6 @@
 A lottery with progressive jackpots that only expires when someone wins.
 
-To get a chance to win, you must buy a ticket _and choose a number for your ticket_. You can choose numbers **from 0 to {{math.floor(16^3)}}**. You can buy any number of tickets you want.
+To get a chance to win, you must buy a ticket _and choose a number for your ticket_. You can choose numbers **from 0 to {{math.floor(16^3 - 1)}}**. You can buy any number of tickets you want.
 
 Drawings are limited to one every _144 blocks_ (1 day). Anyone can initiate a draw.
 

--- a/contracts/c680z7fefr/contract.lua
+++ b/contracts/c680z7fefr/contract.lua
@@ -14,7 +14,7 @@ function buyticket ()
   end
 
   local number = math.floor(tonumber(call.payload.number))
-  local max = 16^3
+  local max = 16^3 - 1
   if type(number) ~= 'number' or number > max or number < 0 then
     error('number must be a number between 0 and ' .. max)
   end


### PR DESCRIPTION
Possible numbers are from 0x000 to 0xFFF, or 0 and 4095 (not 4096). 